### PR TITLE
Refactor method signature of Node class constructor

### DIFF
--- a/src/circular.js
+++ b/src/circular.js
@@ -37,7 +37,7 @@ class Circular extends List {
 
   _addHead(value) {
     const {_head} = this;
-    const node = new Node({value});
+    const node = new Node(value);
     this._head = node;
     this._head.next = this.length === 0 ? node : _head;
     this._length++;
@@ -46,7 +46,7 @@ class Circular extends List {
   }
 
   _addNode(value, index = this.length) {
-    const node = new Node({value});
+    const node = new Node(value);
     const prev = this._getNode(index - 1);
     node.next = prev.next;
     this._length++;

--- a/src/linear.js
+++ b/src/linear.js
@@ -37,14 +37,14 @@ class Linear extends List {
 
   _addHead(value) {
     const {_head} = this;
-    this._head = new Node({value});
+    this._head = new Node(value);
     this._head.next = _head;
     this._length++;
     return this;
   }
 
   _addNode(value, index = this.length) {
-    const node = new Node({value});
+    const node = new Node(value);
     const prev = this._getNode(index - 1);
     node.next = prev.next;
     prev.next = node;

--- a/src/node.js
+++ b/src/node.js
@@ -1,8 +1,8 @@
 'use strict';
 
 class Node {
-  constructor(options = {}) {
-    this._value = options.value;
+  constructor(value) {
+    this._value = value;
     this._next = null;
   }
 

--- a/test/circular/multiple.js
+++ b/test/circular/multiple.js
@@ -24,15 +24,15 @@ test('get nodes value', t => {
 });
 
 test('select node', t => {
-  const a = new Node({value: 'A'});
-  const b = new Node({value: 'B'});
+  const a = new Node('A');
+  const b = new Node('B');
   [a.next, b.next] = [b, a];
   t.deepEqual(circular.node(1), b);
 });
 
 test('next node', t => {
-  const a = new Node({value: 'A'});
-  const b = new Node({value: 'B'});
+  const a = new Node('A');
+  const b = new Node('B');
   [a.next, b.next] = [b, a];
   t.deepEqual(circular.node(0).next, b);
 });

--- a/test/linear/multiple.js
+++ b/test/linear/multiple.js
@@ -30,7 +30,7 @@ test('select node', t => {
 });
 
 test('next node', t => {
-  const node = new Node({value: 'B'});
+  const node = new Node('B');
   t.deepEqual(linear.node(0).next, node);
 });
 

--- a/types/singlie.d.ts
+++ b/types/singlie.d.ts
@@ -1,6 +1,6 @@
 declare namespace node {
   export interface Constructor {
-    new (options?: { value?: any }): Instance;
+    new (value?: any): Instance;
   }
 
   export interface Instance {


### PR DESCRIPTION
## Description

The PR refactors the signature of the `Node` class constructor method, by simplifying the definition of its parameters, thus making easier the instantiation process. The TypeScript ambient declarations are also refactored accordingly.

```js
// Instantiation before
const node = new Node({ value: 'A'});  // Until now, input argument was wrapped in an object
//=> Node { value: 'A', next: null }

// Instantiation now
const node = new Node('A');  // Directly supply the input argument
//=> Node { value: 'A', next: null }
```