### PR TITLE
Add new `List#includes(value)` class method

### DIFF
--- a/src/circular.js
+++ b/src/circular.js
@@ -102,6 +102,22 @@ class Circular extends List {
     return this;
   }
 
+  includes(value) {
+    let {_head: node} = this;
+
+    if (node) {
+      do {
+        if (node.value === value) {
+          return true;
+        }
+
+        node = node.next;
+      } while (node !== this._head);
+    }
+
+    return false;
+  }
+
   insert({value, index}) {
     this._arrayify(value).forEach(x => {
       if (index === 0) {

--- a/src/linear.js
+++ b/src/linear.js
@@ -95,6 +95,20 @@ class Linear extends List {
     return this;
   }
 
+  includes(value) {
+    let {_head: node} = this;
+
+    while (node) {
+      if (node.value === value) {
+        return true;
+      }
+
+      node = node.next;
+    }
+
+    return false;
+  }
+
   insert({value, index}) {
     this._arrayify(value).forEach(x => {
       if (index === 0) {

--- a/test/circular/empty.js
+++ b/test/circular/empty.js
@@ -97,3 +97,8 @@ test('isLinear', t => {
 test('isCircular', t => {
   t.is(circular.isCircular(), true);
 });
+
+test('includes', t => {
+  t.is(circular.includes(), false);
+  t.is(circular.includes(1), false);
+});

--- a/test/circular/multiple.js
+++ b/test/circular/multiple.js
@@ -182,3 +182,10 @@ test('chain', t => {
   t.is(result.join(' '), '[D] [C] [B] [A]');
   t.is(result.node(result.length - 1).next.value, result.head.value);
 });
+
+test('includes', t => {
+  circular.clear().append(5, 10, 15, 20, 25, 30);
+  t.is(circular.includes(), false);
+  t.is(circular.includes(0), false);
+  t.is(circular.includes(25), true);
+});

--- a/test/circular/single.js
+++ b/test/circular/single.js
@@ -118,3 +118,10 @@ test('isLinear', t => {
 test('isCircular', t => {
   t.is(circular.isCircular(), true);
 });
+
+test('includes', t => {
+  circular.clear().append(5);
+  t.is(circular.includes(), false);
+  t.is(circular.includes(0), false);
+  t.is(circular.includes(5), true);
+});

--- a/test/linear/empty.js
+++ b/test/linear/empty.js
@@ -93,3 +93,8 @@ test('isLinear', t => {
 test('isCircular', t => {
   t.is(linear.isCircular(), false);
 });
+
+test('includes', t => {
+  t.is(linear.includes(), false);
+  t.is(linear.includes(1), false);
+});

--- a/test/linear/multiple.js
+++ b/test/linear/multiple.js
@@ -168,3 +168,10 @@ test('chain', t => {
   t.deepEqual(result.toArray(), ['[D]', '[C]', '[B]', '[A]']);
   t.is(result.join(' '), '[D] [C] [B] [A]');
 });
+
+test('includes', t => {
+  linear.clear().append(5, 10, 15, 20, 25, 30);
+  t.is(linear.includes(), false);
+  t.is(linear.includes(0), false);
+  t.is(linear.includes(25), true);
+});

--- a/test/linear/single.js
+++ b/test/linear/single.js
@@ -117,3 +117,10 @@ test('isLinear', t => {
 test('isCircular', t => {
   t.is(linear.isCircular(), false);
 });
+
+test('includes', t => {
+  linear.clear().append(5);
+  t.is(linear.includes(), false);
+  t.is(linear.includes(0), false);
+  t.is(linear.includes(5), true);
+});

--- a/test/types/circular.ts
+++ b/test/types/circular.ts
@@ -54,3 +54,7 @@ circular
 
 // Clear the list
 circular.clear(); // => Circular { head: null, last: null, length: 0 }
+
+circular.append('R', 'O', 'G');
+circular.includes('G'); //=> true
+circular.includes('D'); //=> false

--- a/test/types/linear.ts
+++ b/test/types/linear.ts
@@ -52,3 +52,7 @@ linear
 
 // Clear the list
 linear.clear(); // => Linear { head: null, last: null, length: 0 }
+
+linear.append('R', 'O', 'G');
+linear.includes('G'); //=> true
+linear.includes('D'); //=> false

--- a/types/singlie.d.ts
+++ b/types/singlie.d.ts
@@ -19,6 +19,7 @@ declare namespace list {
     filter(fn: (value: T) => boolean): this;
     forEach(fn: (value: T) => any): this;
     get(index: number): T;
+    includes(value: T): boolean;
     insert(opts: { value: T | T[]; index: number }): this;
     isCircular(): boolean;
     isEmpty(): boolean;


### PR DESCRIPTION
## Description

The PR introduces two new unary methods: 

- `Circular#includes(value)`
- `Linear#includes(value)` 

The methods can be used to determine whether a circular or linear list, includes a certain value among its nodes, returning `true` or `false` as appropriate.

Also, the corresponding test cases & TypeScript ambient declarations are included in the PR.
