### PR TITLE
Replace `any` default type for generics with `unknown`

### DIFF
--- a/types/singlie.d.ts
+++ b/types/singlie.d.ts
@@ -1,9 +1,9 @@
 declare namespace node {
   export interface Constructor {
-    new <T = any>(value?: T): Instance<T>;
+    new <T = unknown>(value?: T): Instance<T>;
   }
 
-  export interface Instance<T = any> {
+  export interface Instance<T = unknown> {
     value: T;
     next: Instance<T> | null;
   }
@@ -47,10 +47,10 @@ declare namespace linear {
   }
 
   export interface Constructor {
-    new <T = any>(): Instance<T>;
+    new <T = unknown>(): Instance<T>;
   }
 
-  interface Instance<T = any> extends list.Instance<T> {
+  interface Instance<T = unknown> extends list.Instance<T> {
     readonly head: HeadNode<T> | null;
     readonly last: LastNode<T> | null;
     map<U>(fn: (value: T) => U): Instance<U>;
@@ -70,10 +70,10 @@ declare namespace circular {
   }
 
   export interface Constructor {
-    new <T = any>(): Instance<T>;
+    new <T = unknown>(): Instance<T>;
   }
 
-  interface Instance<T = any> extends list.Instance<T> {
+  interface Instance<T = unknown> extends list.Instance<T> {
     readonly head: HeadNode<T> | null;
     readonly last: LastNode<T> | null;
     map<U>(fn: (value: T) => U): Instance<U>;
@@ -82,9 +82,9 @@ declare namespace circular {
 }
 
 declare namespace singlie {
-  export interface Circular<T = any> extends circular.Instance<T> {}
-  export interface Linear<T = any> extends linear.Instance<T> {}
-  export interface Node<T = any> extends node.Instance<T> {}
+  export interface Circular<T = unknown> extends circular.Instance<T> {}
+  export interface Linear<T = unknown> extends linear.Instance<T> {}
+  export interface Node<T = unknown> extends node.Instance<T> {}
 }
 
 declare const singlie: {


### PR DESCRIPTION
## Description
The PR replaces the any type used as the default type for the generic type parameters with the more type-safe [unknown](https://devblogs.microsoft.com/typescript/announcing-typescript-3-0-rc-2/#the-unknown-type) type.